### PR TITLE
Follow Redirect feature now handles 307s

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ usage:
         Number of days for which the TLS certificate must be valid before a critical state is returned. (default 5)
     -t
         Timeout length in seconds, requests that do not finish before timeout are considered failed. (default 30)
+    -v
+        Verbose output
+    -r int
+        Number of redirects to follow.
+    -u string (default=check_https_go)
+        Custom user-agent string.
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ usage:
     -v
         Verbose output
     -r int
-        Number of redirects to follow.
+        Number of redirects to follow (will follow 301s, 302s, & 307s).
     -u string (default=check_https_go)
         Custom user-agent string.
 ```

--- a/check/http.go
+++ b/check/http.go
@@ -77,7 +77,7 @@ func (h *HTTPCheck) CheckStatus(redirects int, userAgent string, timeoutduration
 			return r
 		}
 
-		if resp.StatusCode == 301 || resp.StatusCode == 302 {
+		if resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 307 {
 			l := resp.Header.Get("Location")
 			r.VerboseValue += url + " redirected (" + resp.Status + ") to " + l + "\n"
 


### PR DESCRIPTION
The redirect following feature only followed 301s and 302s. It now follows 307s.

At some point this should probably be updates to include all possible redirecting HTTP status codes, but these three cover 99.9% of redirects seen in the wild.