### PR TITLE
Added parameter for configuring status code check.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+on:
+  release:
+    types: [created]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz"
+        binary_name: "check_https_go"
+        extra_files: LICENSE README.md

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Golang Icinga/Nagios HTTPS Checker
 
-Icinga/Nagios plugin, checks that a site returns a 2xx-series `status code`, `returns content`, and has a `valid certificate`.
+Icinga/Nagios plugin, checks that a site returns an `expected status code`, `returns expected content`, and has a `valid certificate`.
 
 User configurable `warning` and `critical` levels for the number of days left in the certificate validity period.
 
@@ -36,6 +36,8 @@ usage:
     -h string
         Fully-qualified domain name to check.
   optional
+    -a string
+        Comma-seperated list of status codes. (default "200,201,202,203,204,205,206,207,208,226")
     -c int
             Number of days for which the TLS certificate must be valid before a critical state is returned. (default 5)
     -r int
@@ -52,6 +54,8 @@ usage:
 ```
 
 ## Version history
+
+1.4—Add parameter for configuring status code check.
 1.3—Add custom string to check the content returned by the page.
 1.2—Follow Redirect feature now handles 307s.
 1.1—Added configurable timeout. Default remains at 30, but you can now increase or decrease this.


### PR DESCRIPTION
The optional `-a` flag can now be used to specify which status codes are accepted as `good`. The default remains the same as before.